### PR TITLE
fix(python): Correct unterminated string literal in agent_logic.py

### DIFF
--- a/api_python/agent_logic.py
+++ b/api_python/agent_logic.py
@@ -275,11 +275,8 @@ def fetch_url_content(url_to_fetch: str) -> Dict[str, Any]: # Renamed
 
         if doc_object:
             raw_page_content = doc_object.page_content # Renamed
-            cleaned_page_content = re.sub(r'
-\s*
-', '
-
-', raw_page_content).strip() # Renamed
+            # Corrected re.sub call to handle newlines properly
+            cleaned_page_content = re.sub(r'\n\s*\n', '\n\n', raw_page_content).strip()
             summary_text = cleaned_page_content[:1000] # Increased summary length
             document_title = doc_object.metadata.get("title", "") or os.path.basename(url_to_fetch) # Renamed
             if not document_title: document_title = "Untitled Document"

--- a/api_python/requirements.txt
+++ b/api_python/requirements.txt
@@ -5,11 +5,9 @@ pydantic
 # Langchain stack
 langchain
 langchain-core
-langgraph # Added: For StateGraph
+langgraph
 langchain_community
-langchain-google-genai # Added: For init_chat_model with "google_genai" provider (Gemini)
-# langchain-openai # Removed: Assuming primary LLM is Google GenAI as per agent code
-# openai # Removed: Assuming primary LLM is Google GenAI
+langchain-google-genai # For init_chat_model with "google_genai" provider (Gemini)
 
 # Vector Store and Embeddings
 sentence-transformers # For HuggingFaceEmbeddings
@@ -17,7 +15,7 @@ faiss-cpu # For FAISS vector store
 
 # Web requests and utilities
 requests # For Tavily API calls and WebBaseLoader sub-dependency
-beautifulsoup4 # Often a good companion for WebBaseLoader for parsing HTML
+beautifulsoup4 # For WebBaseLoader, helps parse HTML
 
 # Environment and Async/Retry
 python-dotenv # For .env file loading
@@ -28,7 +26,7 @@ cachetools # For TTLCache
 google-generativeai # Explicitly listed, might be used by init_chat_model or directly
 
 # Notes:
-# - Ensure API keys (TAVILY_API_KEY, GOOGLE_API_KEY) are set in the Vercel environment.
+# - Ensure API keys (TAVILY_API_KEY, GOOGLE_API_KEY) are set in the Vercel environment for the Python function.
 # - Versions can be pinned for more stable deployments (e.g., fastapi==0.100.0).
-# - sqlite3 is part of Python's standard library, no need to list it.
-# - csv, json, shutil, re, datetime, typing, uuid, os, traceback, argparse are standard libraries.
+# - Standard libraries like sqlite3, csv, json, shutil, re, datetime, typing, uuid, os, traceback, argparse
+#   are part of Python and do not need to be listed here.


### PR DESCRIPTION
This commit fixes a SyntaxError: unterminated string literal in the `fetch_url_content` function within `api_python/agent_logic.py`. The error was caused by an improperly formatted multi-line raw string in an `re.sub()` call.

The line has been corrected to the intended regular expression for cleaning newline characters from web page content:
`cleaned_page_content = re.sub(r'
\s*
', '

', raw_page_content).strip()`

This ensures the Python FastAPI service can start without this syntax error.