### PR TITLE
fix: Resolve ImportError for agent_logic.py functions

### DIFF
--- a/api_python/main.py
+++ b/api_python/main.py
@@ -4,16 +4,15 @@ from typing import List, Dict, Any, Optional
 import logging
 import os
 
-# Attempt to import from agent_logic. Ensure PYTHONPATH is correct for Vercel or local.
-# Vercel should handle this if agent_logic.py is in the same directory.
-try:
-    from agent_logic import chat_with_agent, load_chat_history, init_db as init_agent_db, run_market_intelligence_agent
-    # Assuming agent_logic.py uses its own logger internally now.
-except ImportError:
-    # Fallback for local dev if PYTHONPATH isn't set, assuming it's in the same dir
-    import sys
-    sys.path.append(os.path.dirname(__file__))
-    from agent_logic import chat_with_agent, load_chat_history, init_db as init_agent_db, run_market_intelligence_agent
+from agent_logic import (
+    chat_with_agent,
+    load_chat_history,
+    init_db as init_agent_db, # Keep alias if used consistently
+    run_market_intelligence_agent
+)
+# Assuming agent_logic.py uses its own logger internally now.
+# Vercel's build process should handle placing agent_logic.py where it can be imported directly.
+# The PYTHONPATH in vercel.json might also assist if needed, but direct import is cleaner.
 
 
 # Pydantic models for request and response


### PR DESCRIPTION
This commit addresses an `ImportError: cannot import name 'chat_with_agent' from 'agent_logic'` that occurred when `api_python/main.py` attempted to import from `api_python/agent_logic.py`.

Changes include:
1.  Ensured `api_python/agent_logic.py` contains the complete and correct `Agent.py` code you provided. This guarantees that all necessary functions, including `chat_with_agent`, `run_market_intelligence_agent`, `init_db`, and `load_chat_history`, are defined at the top level of the module.
2.  Simplified the import statements in `api_python/main.py` by removing the `try-except ImportError` block that manipulated `sys.path`. Direct imports are now used, which is cleaner and should work correctly as both files are in the same directory.

These changes ensure that the FastAPI service can correctly import and utilize the core logic from the agent script, resolving the runtime import error.